### PR TITLE
feat: added copy sharable link feature using javascript

### DIFF
--- a/Projects_By_Contributors/Copy Sharable Link Feature - using Javascript/css/styles.css
+++ b/Projects_By_Contributors/Copy Sharable Link Feature - using Javascript/css/styles.css
@@ -1,0 +1,41 @@
+body {
+	font-family: Arial, sans-serif;
+	background-color: #f0f0f0;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	height: 100vh;
+	margin: 0;
+}
+
+.container {
+	background-color: #fff;
+	border: 1px solid #ccc;
+	padding: 20px;
+	border-radius: 5px;
+	box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+}
+
+input[type='text'] {
+	width: 100%;
+	padding: 10px;
+	margin-bottom: 10px;
+	border: 1px solid #ccc;
+	border-radius: 3px;
+}
+
+button {
+	padding: 10px 20px;
+	background-color: #007bff;
+	color: #fff;
+	border: none;
+	border-radius: 3px;
+	cursor: pointer;
+}
+
+button:hover {
+	background-color: #0056b3;
+}

--- a/Projects_By_Contributors/Copy Sharable Link Feature - using Javascript/index.html
+++ b/Projects_By_Contributors/Copy Sharable Link Feature - using Javascript/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta
+			name="viewport"
+			content="width=device-width, initial-scale=1.0" />
+		<link
+			rel="stylesheet"
+			href="css/styles.css" />
+		<title>Copy Sharable Link</title>
+	</head>
+	<body>
+		<div class="container">
+			<input
+				type="text"
+				id="sharableLink"
+				value="https://hacktoberfest.com/" />
+			<button id="copyButton">Copy Link</button>
+		</div>
+
+		<script src="js/script.js"></script>
+	</body>
+</html>

--- a/Projects_By_Contributors/Copy Sharable Link Feature - using Javascript/js/script.js
+++ b/Projects_By_Contributors/Copy Sharable Link Feature - using Javascript/js/script.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', function () {
+	const sharableLinkInput = document.getElementById('sharableLink');
+	const copyButton = document.getElementById('copyButton');
+
+	copyButton.addEventListener('click', function () {
+		sharableLinkInput.select();
+		document.execCommand('copy');
+		alert('Link copied to clipboard!');
+	});
+});


### PR DESCRIPTION
This pull request introduces a new feature to the repository: a Copy Sharable Link Feature - using Javascript. It helps you to understand how we can copy the link to the clipboard using javascript which can be shared easily.

Here's an overview of the changes made in this pull request:

A new directory called "Copy Sharable Link Feature - using Javascript" has been created with all the necessary files and folders required for the project. This helps in keeping the project organized.

A website had a link of "https://hacktoberfest.com/" which can be copied to clipboard and can be shared with anyone.

This pull request adds a valuable feature to the repository: a Copy Sharable Link Feature - using Javascript. It's not just fun but also educational, making it great for beginners learning web development. The changes are well-organized and enhance the project's quality. 👍

Here is the screenshot of the project:
![shareable-link-1](https://github.com/theravi04/HacktoberFest-23/assets/8438258/e04fb536-4d7c-4d5a-8a05-a93274359f8f)

![shareable-link-2](https://github.com/theravi04/HacktoberFest-23/assets/8438258/327eda11-2fed-4161-90a3-fcb8bdf3736d)
